### PR TITLE
Fix polkadex decoding

### DIFF
--- a/chainTypes/polkadexChaintypes.ts
+++ b/chainTypes/polkadexChaintypes.ts
@@ -18,7 +18,8 @@ const definitions: OverrideBundleDefinition = {
           periodCount: 'u32',
           perPeriod: 'Compact<Balance>'
         },
-        VestingScheduleOf: 'OrmlVestingSchedule'
+        VestingScheduleOf: 'OrmlVestingSchedule',
+        DispatchError: 'DispatchErrorPre6First',
       }
     }
   ]
@@ -26,7 +27,7 @@ const definitions: OverrideBundleDefinition = {
 
 const typesBundle = {
     spec: {
-        'node-polkadex': definitions
+        'node': definitions
     }
 }
 

--- a/polkadex.yaml
+++ b/polkadex.yaml
@@ -21,7 +21,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 1
+    startBlock: 23963
     mapping:
       file: ./dist/index.js
       handlers:

--- a/polkadex.yaml
+++ b/polkadex.yaml
@@ -21,7 +21,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 23963
+    startBlock: 1
     mapping:
       file: ./dist/index.js
       handlers:


### PR DESCRIPTION
Similarily to #214 Polkadex has outadted version of DispatchError on older blocks
Polkadex also changed spec-name so types override did not apply at all
