### PR TITLE
Fix - missing rewards paid out via forceBatch

### DIFF
--- a/src/mappings/common.ts
+++ b/src/mappings/common.ts
@@ -5,7 +5,7 @@ import {CallBase} from "@polkadot/types/types/calls";
 import {AnyTuple} from "@polkadot/types/types/codec";
 import { Vec, GenericEventData } from '@polkadot/types';
 
-const batchCalls = ["batch", "batchAll"]
+const batchCalls = ["batch", "batchAll", "forceBatch"]
 const transferCalls = ["transfer", "transferKeepAlive"]
 const ormlSections = ["currencies", "tokens"]
 


### PR DESCRIPTION
Currently `isBatch` does not detect `forceBatch` which cause indexer to ignore rewards paid out via `forceBatch`. Example of reward that is missing on the prod indexer: https://polkadot.subscan.io/extrinsic/15837091-4?event=15837091-79

<img width="1184" alt="image" src="https://github.com/novasamatech/subquery-nova/assets/70131744/9bebf125-27c3-48de-b763-73f055b1c73f">

After applying fix
<img width="1792" alt="image" src="https://github.com/novasamatech/subquery-nova/assets/70131744/88eb19b6-ea8d-4e51-b0b6-5532852a0d80">
