### PR TITLE
Era cache for parachains implemented

### DIFF
--- a/src/mappings/Cache.ts
+++ b/src/mappings/Cache.ts
@@ -8,7 +8,7 @@ import {PalletStakingRewardDestination} from "@polkadot/types/lookup"
 let rewardDestinationByAddress: {[blockId: string]: {[address: string]: PalletStakingRewardDestination}} = {}
 let controllersByStash: {[blockId: string]: {[address: string]: string}} = {}
 
-let parachainEra: {[blockId: string]: number} = {}
+let parachainStakingRewardEra: {[blockId: string]: number} = {}
 
 export async function cachedRewardDestination(accountAddress: string, event: SubstrateEvent): Promise<PalletStakingRewardDestination> {
     const blockId = blockNumber(event)
@@ -124,9 +124,9 @@ export async function cachedController(accountAddress: string, event: SubstrateE
     }
 }
 
-export async function cachedEraIndex(event: SubstrateEvent): Promise<number> {
+export async function cachedStakingRewardEraIndex(event: SubstrateEvent): Promise<number> {
     const blockId = blockNumber(event)
-    let cachedEra = parachainEra[blockId]
+    let cachedEra = parachainStakingRewardEra[blockId]
 
     if (cachedEra !== undefined) {
         return cachedEra
@@ -137,8 +137,8 @@ export async function cachedEraIndex(event: SubstrateEvent): Promise<number> {
         // HACK: used to get data from object
         const eraIndex = (era.toJSON() as {current: any}).current - Number(paymentDelay)
 
-        parachainEra = {}
-        parachainEra[blockId] = eraIndex
+        parachainStakingRewardEra = {}
+        parachainStakingRewardEra[blockId] = eraIndex
         return eraIndex
     }
 }

--- a/src/mappings/Cache.ts
+++ b/src/mappings/Cache.ts
@@ -8,6 +8,8 @@ import {PalletStakingRewardDestination} from "@polkadot/types/lookup"
 let rewardDestinationByAddress: {[blockId: string]: {[address: string]: PalletStakingRewardDestination}} = {}
 let controllersByStash: {[blockId: string]: {[address: string]: string}} = {}
 
+let parachainEra: {[blockId: string]: number} = {}
+
 export async function cachedRewardDestination(accountAddress: string, event: SubstrateEvent): Promise<PalletStakingRewardDestination> {
     const blockId = blockNumber(event)
     let cachedBlock = rewardDestinationByAddress[blockId]
@@ -119,5 +121,24 @@ export async function cachedController(accountAddress: string, event: SubstrateE
         })
         controllersByStash[blockId] = bondedByAddress
         return bondedByAddress[accountAddress]
+    }
+}
+
+export async function cachedEraIndex(event: SubstrateEvent): Promise<number> {
+    const blockId = blockNumber(event)
+    let cachedEra = parachainEra[blockId]
+
+    if (cachedEra !== undefined) {
+        return cachedEra
+    } else {
+        const era = await api.query.parachainStaking.round()
+
+        const paymentDelay = api.consts.parachainStaking.rewardPaymentDelay.toHuman()
+        // HACK: used to get data from object
+        const eraIndex = (era.toJSON() as {current: any}).current - Number(paymentDelay)
+
+        parachainEra = {}
+        parachainEra[blockId] = eraIndex
+        return eraIndex
     }
 }

--- a/src/mappings/Rewards.ts
+++ b/src/mappings/Rewards.ts
@@ -15,7 +15,7 @@ import {CallBase} from "@polkadot/types/types/calls";
 import {AnyTuple} from "@polkadot/types/types/codec";
 import {EraIndex} from "@polkadot/types/interfaces/staking"
 import {Balance} from "@polkadot/types/interfaces";
-import {cachedRewardDestination, cachedController, cachedEraIndex} from "./Cache"
+import {cachedRewardDestination, cachedController, cachedStakingRewardEraIndex} from "./Cache"
 
 function isPayoutStakers(call: CallBase<AnyTuple>): boolean {
     return call.method == "payoutStakers"
@@ -334,7 +334,7 @@ async function handleParachainRewardForTxHistory(rewardEvent: SubstrateEvent): P
     const blockTimestamp = timestamp(block)
     const {event: {data: [account, amount]}} = rewardEvent
     const eventId = eventIdFromBlockAndIdx(blockNumber, rewardEvent.idx.toString())
-    const eraIndex = await cachedEraIndex(rewardEvent)
+    const eraIndex = await cachedStakingRewardEraIndex(rewardEvent)
 
     const validatorEvent = rewardEvent.block.events.find(event =>
         event.event.section == rewardEvent.event.section && 

--- a/src/mappings/Rewards.ts
+++ b/src/mappings/Rewards.ts
@@ -15,7 +15,7 @@ import {CallBase} from "@polkadot/types/types/calls";
 import {AnyTuple} from "@polkadot/types/types/codec";
 import {EraIndex} from "@polkadot/types/interfaces/staking"
 import {Balance} from "@polkadot/types/interfaces";
-import {cachedRewardDestination, cachedController} from "./Cache"
+import {cachedRewardDestination, cachedController, cachedEraIndex} from "./Cache"
 
 function isPayoutStakers(call: CallBase<AnyTuple>): boolean {
     return call.method == "payoutStakers"
@@ -334,11 +334,7 @@ async function handleParachainRewardForTxHistory(rewardEvent: SubstrateEvent): P
     const blockTimestamp = timestamp(block)
     const {event: {data: [account, amount]}} = rewardEvent
     const eventId = eventIdFromBlockAndIdx(blockNumber, rewardEvent.idx.toString())
-    const era = await api.query.parachainStaking.round();
-
-    const paymentDelay = api.consts.parachainStaking.rewardPaymentDelay.toHuman();
-    // HACK: used to get data from object
-    const eraIndex = (era.toJSON() as {current: any}).current - Number(paymentDelay)
+    const eraIndex = await cachedEraIndex(rewardEvent)
 
     const validatorEvent = rewardEvent.block.events.find(event =>
         event.event.section == rewardEvent.event.section && 


### PR DESCRIPTION
Reduced the number of queries for block, as often parachains have a lot of reward events in one block. Previously we made query for every event. Now only for first event in block. Tested on moonbeam from 3955801

Graphql:

![Screenshot from 2023-07-09 16-45-40](https://github.com/novasamatech/subquery-nova/assets/33938211/99dcd5c1-19d8-49da-a05d-ae00eaed47f0)


Logs explained:
![Screenshot from 2023-07-09 15-41-39](https://github.com/novasamatech/subquery-nova/assets/33938211/75868ba7-b74f-478f-9828-2df1437810de)

Logs evidences:
![Screenshot from 2023-07-09 15-41-16](https://github.com/novasamatech/subquery-nova/assets/33938211/7843e384-20ce-43c8-b533-f9ae3981339f)

 
![Screenshot from 2023-07-09 16-48-36](https://github.com/novasamatech/subquery-nova/assets/33938211/b00e4c1f-2015-492e-9ee6-d5d9c60df683)


Logs:

[moonbeam.log](https://github.com/novasamatech/subquery-nova/files/11995425/moonbeam.log)
